### PR TITLE
Macos support and device dialoge selection

### DIFF
--- a/src/openwhoop/Cargo.toml
+++ b/src/openwhoop/Cargo.toml
@@ -19,4 +19,5 @@ migration.path = "../sea-migrations"
 sea-orm = "1.1.4"
 tokio = { version = "1.43.0", features = ["rt-multi-thread", "macros"] }
 uuid = { version = "1.11.1", features = ["v4"] }
+dialoguer = "0.10"
 whoop = { version = "0.1.0", path = "../whoop" }

--- a/src/openwhoop/src/main.rs
+++ b/src/openwhoop/src/main.rs
@@ -1,17 +1,21 @@
 #[macro_use]
 extern crate log;
 
+use std::collections::HashSet;
+use std::env;
 use std::time::Duration;
 
 use anyhow::anyhow;
 use btleplug::{
-    api::{BDAddr, Central, Manager as _, Peripheral as _, ScanFilter},
+    api::{BDAddr, Central, Peripheral as _, ScanFilter, Manager as _}, 
     platform::{Adapter, Manager, Peripheral},
 };
+
 use clap::{Parser, Subcommand};
+use dialoguer::Select;
 use dotenv::dotenv;
 use openwhoop::{DatabaseHandler, OpenWhoop, WhoopDevice};
-use tokio::time::sleep;
+use tokio::time::{sleep, Instant};
 use whoop::{constants::WHOOP_SERVICE, WhoopPacket};
 
 #[derive(Parser)]
@@ -29,7 +33,7 @@ pub enum OpenWhoopCommand {
     Scan,
     DownloadHistory {
         #[arg(long, env)]
-        whoop_addr: BDAddr,
+        whoop_addr: Option<BDAddr>,
     },
     ReRun,
     DetectEvents,
@@ -37,9 +41,21 @@ pub enum OpenWhoopCommand {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // Load environment variables from .env.
     if let Err(error) = dotenv() {
         println!("{}", error);
     }
+    
+    // If running on macOS, remove the ble_interface variable so that Linux‑only configuration isn’t used.
+    // On macos shows all BLE addresses as 00:00:00:00:00:00
+    // We remove the BLE interface and BLE_INTEFACE from the .env, so that we can use 
+    // the interactive shell in the cli on the macos platform
+    if cfg!(target_os = "macos") {
+        // Every BLE address is 00:00:00:00:00, so we cant filter for it.
+        env::remove_var("BLE_INTERFACE"); 
+        env::remove_var("WHOOP_ADDR");
+    }
+
 
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
         .filter_module("sqlx::query", log::LevelFilter::Off)
@@ -60,7 +76,6 @@ async fn main() -> anyhow::Result<()> {
                     break;
                 }
             }
-
             c_adapter?
         }
         None => {
@@ -74,18 +89,20 @@ async fn main() -> anyhow::Result<()> {
 
     match cli.subcommand {
         OpenWhoopCommand::Scan => {
-            scan_command(adapter, None).await?;
+            let _ = scan_command(adapter, None).await?;
             Ok(())
         }
         OpenWhoopCommand::DownloadHistory { whoop_addr } => {
-            let peripheral = scan_command(adapter, Some(whoop_addr)).await?;
+            // On macOS (or when no address is provided), 
+            // the scan_command will prompt for a selection.
+            // Maybe we want to write the name after first selection into .env?
+            let peripheral = scan_command(adapter, whoop_addr).await?;
             let mut whoop = WhoopDevice::new(peripheral, db_handler);
 
             whoop.connect().await?;
             whoop.initialize().await?;
 
-            let result = whoop.sync_history().await;
-            if let Err(e) = result {
+            if let Err(e) = whoop.sync_history().await {
                 error!("{}", e);
             }
 
@@ -130,6 +147,18 @@ async fn main() -> anyhow::Result<()> {
     }
 }
 
+/// Scans for devices advertising the WHOOP_SERVICE.
+///
+/// If a peripheral address is provided, this function waits until that specific device is found.
+/// Otherwise, it scans for a fixed duration and then presents the user with an interactive
+/// selection prompt
+///
+/// **New functionality on macOS:**
+///
+/// Because macOS reports the same dummy BLE address for all devices (00:00:00:00:00:00),
+/// we build a composte key using both the device's local name and its unique ID: peripheral.id
+/// Thi sunique identifier differentiates devices even when their advertised adress is the same.
+
 async fn scan_command(
     adapter: Adapter,
     peripheral_addr: Option<BDAddr>,
@@ -140,31 +169,79 @@ async fn scan_command(
         })
         .await?;
 
-    loop {
-        let peripherals = adapter.peripherals().await?;
-
-        for peripheral in peripherals {
-            let Some(properties) = peripheral.properties().await? else {
-                continue;
-            };
-
-            if !properties.services.contains(&WHOOP_SERVICE) {
-                continue;
+    // Just as before: if an address is provided, wait for that device.
+    if let Some(addr) = peripheral_addr {
+        loop {
+            let peripherals = adapter.peripherals().await?;
+            for peripheral in peripherals {
+                if let Some(props) = peripheral.properties().await? {
+                    if props.address == addr {
+                        return Ok(peripheral);
+                    }
+                }
             }
-
-            let Some(peripheral_addr) = peripheral_addr else {
-                println!("Address: {}", properties.address);
-                println!("Name: {:?}", properties.local_name);
-                println!("RSSI: {:?}", properties.rssi);
-                println!();
-                continue;
-            };
-
-            if properties.address == peripheral_addr {
-                return Ok(peripheral);
-            }
+            sleep(Duration::from_secs(1)).await;
         }
 
-        sleep(Duration::from_secs(1)).await;
+    // Now new for macos and selection dialogue:
+    } else {
+        let mut devices = Vec::new();
+        let mut seen = HashSet::new();
+        let scan_duration = Duration::from_secs(10);
+        let start = Instant::now();
+
+        println!("Scanning for devices for {} seconds...", scan_duration.as_secs());
+        while Instant::now().duration_since(start) < scan_duration {
+            let peripherals = adapter.peripherals().await?;
+            for peripheral in peripherals {
+                if let Some(props) = peripheral.properties().await? {
+                    if !props.services.contains(&WHOOP_SERVICE) {
+                        continue;
+                    }
+                    // Use the peripheral's local name and its unique id, or Unkown
+                    let local_name = props.local_name.unwrap_or_else(|| "Unknown".to_string());
+                    let unique_id = peripheral.id(); // This is unique even on macOS
+                    let key = (local_name.clone(), unique_id);
+                    if seen.insert(key) {
+                        devices.push(peripheral);
+                    }
+                }
+            }
+            sleep(Duration::from_secs(1)).await;
+        }
+
+        if devices.is_empty() {
+            return Err(anyhow!("No devices found"));
+        }
+
+        // Now we make a list of labels for user selection.
+        // Label is: <disvocered_name> : <Address>
+        // Because we only have 00:00:00:00:00 on macos
+        // we take a uniqde id and push it in the list
+        let items = {
+            let mut list = Vec::new();
+            for device in &devices {
+                if let Some(props) = device.properties().await? {
+                    let local_name = props.local_name.unwrap_or_else(|| "Unknown".to_string());
+                    list.push(format!("{} ({})", local_name, props.address));
+                }
+            }
+            list
+        };
+
+        let selection = tokio::task::spawn_blocking(move || {
+            Select::new()
+                .with_prompt("Select a device")
+                .items(&items)
+                .default(0)
+                .interact()
+        })
+        .await??;
+
+        devices
+            .into_iter()
+            .nth(selection)
+            .ok_or(anyhow!("Invalid selection"))
     }
 }
+


### PR DESCRIPTION
Previously, I had to remove the attributes from the .env every time.

I changed that in openwhoop/src/main.rs so that it automatically macos and removes bad attributes (BLE_INTERFACE, WHOOP_ADDR). 

Also I added a cli-dialogue for decice selection which scans for 10 seconds all devices that offer the whoop service and stores it with their advertising names and addresses. 

Then you can choose your device directly in the cli. 

On macos every address is 00:00:00:00:00:00. So here we cant use the WHOOP_ADDR or the adversting BLE address that is shown. Instead we choose the detected device in the cli.