### PR TITLE
Extract cross-platform handling, add macOS support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1792,6 +1792,7 @@ name = "openwhoop"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "btleplug",
  "chrono",
  "clap 4.5.26",

--- a/README.md
+++ b/README.md
@@ -10,7 +10,21 @@ cp .env.example .env
 cargo run -r -- scan
 ```
 
-After you find your device copy its address to `.env` under `WHOOP_ADDR`, and you can download data from your whoop by running:
+After you find your device, set the appropriate environment variable in `.env`:
+
+#### Linux
+Copy the device address to `.env` under `WHOOP_ADDR`:
+```sh
+WHOOP_ADDR=00:11:22:33:44:55
+```
+
+#### macOS
+Copy the device name to `.env` under `WHOOP_NAME`:
+```sh
+WHOOP_NAME="WHOOP 4A0360692"
+```
+
+Then you can download data from your whoop by running:
 ```sh
 cargo run -r -- download-history
 ```
@@ -24,10 +38,9 @@ import os
 
 QUERY = "SELECT time, bpm from heart_rate"
 PREFIX = "sqlite:///" # This is prefix if you are working in same dir as `.env` if you are working in `notebooks/` change to `sqlite:///../`
-DATABASE_URL = os.getenv("DATABASE_URL").replace("sqlite://", PREFIX) 
+DATABASE_URL = os.getenv("DATABASE_URL").replace("sqlite://", PREFIX)
 df = pd.read_sql(QUERY, DATABASE_URL)
 ```
-
 
 ## TODO:
 

--- a/src/openwhoop/Cargo.toml
+++ b/src/openwhoop/Cargo.toml
@@ -6,6 +6,7 @@ default-run = "openwhoop"
 
 [dependencies]
 anyhow = "1.0.95"
+async-trait = "0.1.77"
 btleplug = "0.11.7"
 chrono = "0.4.39"
 clap = { version = "4.5.26", features = ["env", "derive"] }

--- a/src/openwhoop/src/lib.rs
+++ b/src/openwhoop/src/lib.rs
@@ -15,3 +15,6 @@ pub mod algo;
 pub mod types;
 
 pub(crate) mod helpers;
+
+mod platform;
+pub use platform::Platform;

--- a/src/openwhoop/src/platform.rs
+++ b/src/openwhoop/src/platform.rs
@@ -1,0 +1,115 @@
+use anyhow::{anyhow, Result};
+use btleplug::api::PeripheralProperties;
+use std::env;
+
+#[cfg(not(target_os = "macos"))]
+use {btleplug::api::BDAddr, std::str::FromStr};
+
+#[cfg(target_os = "macos")]
+#[derive(Debug)]
+pub struct Platform {
+    identifier: String, // Device name
+}
+
+#[cfg(not(target_os = "macos"))]
+#[derive(Debug)]
+pub struct Platform {
+    identifier: BDAddr, // BLE address
+}
+
+impl Platform {
+    pub fn initialize() -> Result<()> {
+        #[cfg(target_os = "macos")]
+        {
+            env::remove_var("BLE_INTERFACE");
+            env::remove_var("WHOOP_ADDR");
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            env::remove_var("WHOOP_NAME");
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            // btleplug on windows does not display local_name, it also does not connect to the device successfully
+            // While these can be worked-around using lower level windows BLE interfaces it defeats the purpose of cross-platform ble library
+            // so instead we error and do not support windows at this time
+            // https://github.com/deviceplug/btleplug/issues/267
+            // https://github.com/deviceplug/btleplug/issues/301
+            // https://github.com/deviceplug/btleplug/issues/260
+
+            return Err(anyhow!(
+                "Windows is not supported due to compatibility issues"
+            ));
+        }
+
+        Ok(())
+    }
+
+    pub fn from_env() -> Result<Self> {
+        #[cfg(target_os = "macos")]
+        {
+            env::var("WHOOP_NAME")
+                .map(|name| Self { identifier: name })
+                .map_err(|_| anyhow!("WHOOP_NAME environment variable required"))
+        }
+
+        #[cfg(not(target_os = "macos"))]
+        {
+            env::var("WHOOP_ADDR")
+                .map_err(|_| anyhow!("WHOOP_ADDR environment variable required"))
+                .and_then(|addr| {
+                    BDAddr::from_str(&addr).map_err(|_| anyhow!("Invalid BLE address format"))
+                })
+                .map(|addr| Self { identifier: addr })
+        }
+    }
+
+    pub fn matches(&self, properties: &PeripheralProperties) -> bool {
+        #[cfg(target_os = "macos")]
+        {
+            properties
+                .local_name
+                .as_deref()
+                .map(|name| name.eq_ignore_ascii_case(&self.identifier))
+                .unwrap_or(false)
+        }
+
+        #[cfg(not(target_os = "macos"))]
+        {
+            properties.address == self.identifier
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        #[cfg(target_os = "macos")]
+        {
+            self.identifier.clone()
+        }
+
+        #[cfg(not(target_os = "macos"))]
+        {
+            self.identifier.to_string()
+        }
+    }
+
+    pub fn format_device_info(
+        properties: &PeripheralProperties,
+        name: &Option<String>,
+    ) -> Vec<String> {
+        let info = vec![
+            format!(
+                "Name: {}",
+                name.as_ref().unwrap_or(&String::from("Unknown"))
+            ),
+            format!("RSSI: {}", properties.rssi.unwrap_or(0)),
+        ];
+
+        #[cfg(not(target_os = "macos"))]
+        return [vec![format!("Address: {}", properties.address)], info].concat();
+
+        #[cfg(target_os = "macos")]
+        info
+    }
+}


### PR DESCRIPTION
I took a quick stab at cross platform, in a slightly different approach from #3 

* Uses the existing scan and env var workflow
* Drops out the env vars that aren't relevant on each platform
* Adds a platform module to hold all the platform specific code behind gates
* Use a different device identifier (name vs address) for macos and not macos (linux but theoretically windows)
* Tidies up the scan output
* Errors out on Windows


About Windows:

On the face of it windows should be the same as linux (i.e. not macos gate)
however I spent far too long getting windows support working, and the code was far too complex with workarounds so I elected to remove it.
btleplug has some compatibility issues with windows and these vary between 10 and 11. 
local_name is not populated, windows crate can be used to get low level access and merge this in quite straightforwardly - this enables a usable scan
however, when it comes to connecting there are also some issues and I was not able to get data to download, the device would not connect.
Also, I don't use a windows computer much so don't have the juice to properly support that.
