### PR TITLE
improve connection reliability

### DIFF
--- a/src/openwhoop/src/main.rs
+++ b/src/openwhoop/src/main.rs
@@ -344,6 +344,7 @@ async fn scan_command(adapter: Adapter, device_id: Option<DeviceId>) -> anyhow::
 
             #[cfg(target_os = "linux")]
             if properties.address == *device_id {
+                adapter.stop_scan().await?;
                 return Ok(peripheral);
             }
 
@@ -353,6 +354,7 @@ async fn scan_command(adapter: Adapter, device_id: Option<DeviceId>) -> anyhow::
                     continue;
                 };
                 if sanitize_name(&name).starts_with(device_id) {
+                    adapter.stop_scan().await?;
                     return Ok(peripheral);
                 }
             }


### PR DESCRIPTION
I was experiencing similar connection issues as described in #2. The documentation of [start_scan](https://github.com/deviceplug/btleplug/blob/c227cc1adf885e143217f274758968afc02490fb/src/api/mod.rs#L350C5-L351C61) says
> /// Starts a scan for BLE devices. This scan will generally continue until explicitly stopped,
> /// although this may depend on your Bluetooth adapter. 

This got me thinking that the scanning might interfere with data receiving during history download. An open [issue](https://github.com/deviceplug/btleplug/issues/324) with a proposed solution to stop scanning on the Github repo of the BLE library used seems to support this idea. 

After I added the `stop_scan()` I was able to download 2 days worth of data without a single disconnect whereas before it would disconnect every 15-20 seconds.