### PR TITLE
Fix download-history command never exiting

### DIFF
--- a/src/openwhoop/src/device.rs
+++ b/src/openwhoop/src/device.rs
@@ -109,6 +109,10 @@ impl WhoopDevice {
             if should_exit.load(Ordering::SeqCst) {
                 break;
             }
+            if self.whoop.history_complete {
+                info!("History download complete");
+                break;
+            }
             let notification = notifications.next();
             let sleep_ = sleep(Duration::from_secs(10));
 

--- a/src/openwhoop/src/openwhoop.rs
+++ b/src/openwhoop/src/openwhoop.rs
@@ -1,5 +1,5 @@
 use btleplug::api::ValueNotification;
-use chrono::{DateTime, Local, TimeDelta};
+use chrono::{DateTime, Local, TimeDelta, Utc};
 use openwhoop_entities::packets;
 use openwhoop_db::{DatabaseHandler, SearchHistory};
 use openwhoop_codec::{
@@ -20,6 +20,7 @@ pub struct OpenWhoop {
     pub packet: Option<WhoopPacket>,
     pub last_history_packet: Option<HistoryReading>,
     pub history_packets: Vec<HistoryReading>,
+    pub history_complete: bool,
 }
 
 impl OpenWhoop {
@@ -29,6 +30,7 @@ impl OpenWhoop {
             packet: None,
             last_history_packet: None,
             history_packets: Vec::new(),
+            history_complete: false,
         }
     }
 
@@ -119,12 +121,33 @@ impl OpenWhoop {
                 self.history_packets.push(hr);
             }
             WhoopData::HistoryMetadata { data, cmd, .. } => match cmd {
-                MetadataType::HistoryComplete => {}
+                MetadataType::HistoryComplete => {
+                    if !self.history_packets.is_empty() {
+                        self.database
+                            .create_readings(std::mem::take(&mut self.history_packets))
+                            .await?;
+                    }
+                    self.history_complete = true;
+                }
                 MetadataType::HistoryStart => {}
                 MetadataType::HistoryEnd => {
                     self.database
                         .create_readings(std::mem::take(&mut self.history_packets))
                         .await?;
+
+                    // Some firmware never sends HistoryComplete; instead the strap
+                    // simply stops responding once it has handed over everything.
+                    // If our newest reading is within ~60s of now, we've caught up.
+                    let caught_up = self
+                        .last_history_packet
+                        .as_ref()
+                        .and_then(|hr| i64::try_from(hr.unix / 1000).ok())
+                        .is_some_and(|last_secs| Utc::now().timestamp() - last_secs < 60);
+
+                    if caught_up {
+                        self.history_complete = true;
+                        return Ok(None);
+                    }
 
                     let packet = WhoopPacket::history_end(data);
                     return Ok(Some(packet));


### PR DESCRIPTION
## Summary

- `download-history` would loop forever even after the strap had handed over all of its data; only Ctrl+C broke out of it.
- The `MetadataType::HistoryComplete` arm in `handle_data` was a no-op, and current firmware (Harvard 41.16.6.0 / Boylston 17.2.2.0) doesn't appear to emit `HistoryComplete` anyway — the strap simply goes silent.
- Two changes:
  1. New `history_complete: bool` flag on `OpenWhoop`. The `HistoryComplete` handler now flushes any pending readings and sets it. `sync_history` checks the flag at the top of each iteration and breaks cleanly with an info log.
  2. In the `HistoryEnd` handler, after flushing the chunk, check whether the most recent reading is within 60 seconds of `Utc::now()`. If so, mark complete and skip the ACK so the strap isn't asked for a chunk that doesn't exist. This is what actually triggers the exit on the firmware tested.

The 60-second window is generous enough to absorb a slow batch but tight enough to fire as soon as we've actually caught up.

Closes #18

## Test plan

- [x] `cargo build -r` clean
- [x] `cargo test -p openwhoop -p openwhoop-db -p openwhoop-algos` — 98 tests pass
- [x] `cargo run -r -- download-history --whoop "..."` exits on its own with `INFO openwhoop::device History download complete` once the latest reading is within 60s of now
- [x] Tested against WHOOP 4.0, firmware 41.16.6.0 / 17.2.2.0, on macOS
- [ ] Untested on older firmware that may actually emit `HistoryComplete` — the dual-trigger logic should still work there, since `HistoryComplete` also sets the flag